### PR TITLE
Add `isStable()` Instance-method to `SemVer`

### DIFF
--- a/src/main/java/io/github/chrimle/semver/SemVer.java
+++ b/src/main/java/io/github/chrimle/semver/SemVer.java
@@ -144,6 +144,26 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
   }
 
   /**
+   * Returns whether this {@link SemVer} is considered <em>stable</em> according to <a
+   * href="https://semver.org/#spec-item-4">SemVer Spec §4</a>:
+   *
+   * <blockquote>
+   *
+   * Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The
+   * public API SHOULD NOT be considered stable.
+   *
+   * </blockquote>
+   *
+   * @return whether <em>this</em> {@link SemVer} is considered a <em>stable</em> release.
+   * @since 1.4.0
+   */
+  @API(status = API.Status.STABLE, since = "1.4.0")
+  @Contract(pure = true)
+  public boolean isStable() {
+    return major != 0;
+  }
+
+  /**
    * Returns <em>this</em> {@link SemVer} as a {@code String} in the format: {@code
    * v{major}.{minor}.{patch}}.
    *

--- a/src/test/java/io/github/chrimle/semver/SemVerTest.java
+++ b/src/test/java/io/github/chrimle/semver/SemVerTest.java
@@ -248,4 +248,37 @@ class SemVerTest {
       assertEquals(1, right.compareTo(left));
     }
   }
+
+  @Nested
+  class StableTests {
+
+    @ParameterizedTest
+    @CsvSource(
+        value =
+            """
+            0,0,0
+            0,0,1
+            0,1,0
+            0,1,1
+            """)
+    void testNonStable(final int major, final int minor, final int patch) {
+      final var semVer = new SemVer(major, minor, patch);
+      assertFalse(
+          semVer.isStable(), "Expected %s to be non-stable, but is not...".formatted(semVer));
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value =
+            """
+            1,0,0
+            1,0,1
+            1,1,0
+            1,1,1
+            """)
+    void testStable(final int major, final int minor, final int patch) {
+      final var semVer = new SemVer(major, minor, patch);
+      assertTrue(semVer.isStable(), "Expected %s to be stable, but is not...".formatted(semVer));
+    }
+  }
 }


### PR DESCRIPTION
> Adds an instance method `isStable` to the `SemVer`-class, returning whether the SemVer-release is considered stable or not.