### PR TITLE
Apply Full `JSpecify`-annotation Coverage

### DIFF
--- a/src/main/java/io/github/chrimle/semver/SemVer.java
+++ b/src/main/java/io/github/chrimle/semver/SemVer.java
@@ -23,8 +23,6 @@ import static io.github.chrimle.exceptionfactory.MessageTemplates.TwoArgTemplate
 import io.github.chrimle.exceptionfactory.ExceptionBuilder;
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Contract;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents a <em>Release Version Number</em> adhering to <a href="https://semver.org/">Semantic
@@ -71,7 +69,8 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract("null -> fail; !null -> new")
-  public @NonNull SemVer incrementVersion(@Nullable final Change change)
+  @SuppressWarnings({"ConstantValue", "Contract"})
+  public SemVer incrementVersion(final Change change)
       throws ArithmeticException, IllegalArgumentException {
     if (change == null) throw illegalArgumentOf("change", MUST_NOT_BE_NULL);
     return switch (change) {
@@ -92,7 +91,7 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(" -> new")
-  public @NonNull SemVer incrementMajor() throws ArithmeticException {
+  public SemVer incrementMajor() throws ArithmeticException {
     if (major == Integer.MAX_VALUE) {
       throw new ArithmeticException(
           "The next `SemVer` cannot be created with a `major` greater than `Integer.MAX_VALUE` (%d)"
@@ -112,7 +111,7 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(" -> new")
-  public @NonNull SemVer incrementMinor() throws ArithmeticException {
+  public SemVer incrementMinor() throws ArithmeticException {
     if (minor == Integer.MAX_VALUE) {
       throw new ArithmeticException(
           "The next `SemVer` cannot be created with a `minor` greater than `Integer.MAX_VALUE` (%d)"
@@ -132,7 +131,7 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(" -> new")
-  public @NonNull SemVer incrementPatch() throws ArithmeticException {
+  public SemVer incrementPatch() throws ArithmeticException {
     if (patch == Integer.MAX_VALUE) {
       throw new ArithmeticException(
           "The next `SemVer` cannot be created with a `patch` greater than `Integer.MAX_VALUE` (%d)"
@@ -170,7 +169,7 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(value = "-> !null")
-  public @NonNull String toCompleteVersionString() {
+  public String toCompleteVersionString() {
     return "v%d.%d.%d".formatted(major, minor, patch);
   }
 
@@ -191,7 +190,7 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
    */
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(value = "-> !null")
-  public @NonNull String toShortVersionString() {
+  public String toShortVersionString() {
     if (patch > 0) {
       return toCompleteVersionString();
     }
@@ -210,7 +209,8 @@ public record SemVer(int major, int minor, int patch) implements Comparable<SemV
   @API(status = API.Status.STABLE, since = "1.2.0")
   @Contract(value = "null -> fail", pure = true)
   @Override
-  public int compareTo(@Nullable final SemVer other) throws NullPointerException {
+  @SuppressWarnings({"ConstantValue", "Contract"})
+  public int compareTo(final SemVer other) throws NullPointerException {
     if (other == null) {
       throw ExceptionBuilder.of(NullPointerException.class)
           .setMessage(MUST_NOT_BE_NULL, "other")

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,3 @@
-import org.jspecify.annotations.NullMarked;
-
 /**
  * Provides classes for representing, comparing and interacting with Semantic Versions.
  *
@@ -33,7 +31,7 @@ import org.jspecify.annotations.NullMarked;
  * @see <a href="https://github.com/Chrimle/Semantic-Versioning">This Semantic-Versioning Project on
  *     GitHub</a>
  */
-@NullMarked
+@org.jspecify.annotations.NullMarked
 module io.github.chrimle.semver {
   // Exports
   exports io.github.chrimle.semver;

--- a/src/test/java/io/github/chrimle/semver/SemVerTest.java
+++ b/src/test/java/io/github/chrimle/semver/SemVerTest.java
@@ -18,6 +18,7 @@ package io.github.chrimle.semver;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Objects;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,7 +54,7 @@ class SemVerTest {
     void testIncrementAtMaxInteger() {
       final var semVer = new SemVer(Integer.MAX_VALUE, 0, 0);
       final var exception = assertThrows(ArithmeticException.class, semVer::incrementMajor);
-      assertTrue(exception.getMessage().contains("major"));
+      assertTrue(getExceptionMessage(exception).contains("major"));
     }
 
     @Test
@@ -61,7 +62,7 @@ class SemVerTest {
       final var semVer = new SemVer(Integer.MAX_VALUE, 0, 0);
       final var exception =
           assertThrows(ArithmeticException.class, () -> semVer.incrementVersion(Change.MAJOR));
-      assertTrue(exception.getMessage().contains("major"));
+      assertTrue(getExceptionMessage(exception).contains("major"));
     }
   }
 
@@ -93,7 +94,7 @@ class SemVerTest {
     void testIncrementAtMaxInteger() {
       final var semVer = new SemVer(0, Integer.MAX_VALUE, 0);
       final var exception = assertThrows(ArithmeticException.class, semVer::incrementMinor);
-      assertTrue(exception.getMessage().contains("minor"));
+      assertTrue(getExceptionMessage(exception).contains("minor"));
     }
 
     @Test
@@ -101,7 +102,7 @@ class SemVerTest {
       final var semVer = new SemVer(0, Integer.MAX_VALUE, 0);
       final var exception =
           assertThrows(ArithmeticException.class, () -> semVer.incrementVersion(Change.MINOR));
-      assertTrue(exception.getMessage().contains("minor"));
+      assertTrue(getExceptionMessage(exception).contains("minor"));
     }
   }
 
@@ -133,7 +134,7 @@ class SemVerTest {
     void testIncrementAtMaxInteger() {
       final var semVer = new SemVer(0, 0, Integer.MAX_VALUE);
       final var exception = assertThrows(ArithmeticException.class, semVer::incrementPatch);
-      assertTrue(exception.getMessage().contains("patch"));
+      assertTrue(getExceptionMessage(exception).contains("patch"));
     }
 
     @Test
@@ -141,7 +142,7 @@ class SemVerTest {
       final var semVer = new SemVer(0, 0, Integer.MAX_VALUE);
       final var exception =
           assertThrows(ArithmeticException.class, () -> semVer.incrementVersion(Change.PATCH));
-      assertTrue(exception.getMessage().contains("patch"));
+      assertTrue(getExceptionMessage(exception).contains("patch"));
     }
   }
 
@@ -190,6 +191,7 @@ class SemVerTest {
 
   @Nested
   class CompareToTests {
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void testNull() {
       final var semVer = new SemVer(1, 2, 3);
@@ -280,5 +282,9 @@ class SemVerTest {
       final var semVer = new SemVer(major, minor, patch);
       assertTrue(semVer.isStable(), "Expected %s to be stable, but is not...".formatted(semVer));
     }
+  }
+
+  private static String getExceptionMessage(final Exception exception) {
+    return Objects.requireNonNull(exception.getMessage());
   }
 }


### PR DESCRIPTION
> Adds complete `JSpecify` nullability coverage. Includes a fix bug fixes where `@Nullable`-annotations were incorrectly applied.